### PR TITLE
fix: gracefully handle null api results

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,15 +17,9 @@
 
 - name: Parse rc API response
   ansible.builtin.set_fact:
-    rclone_listremotes_contents: "{{ (rclone_listremotes.content | from_json).remotes }}"
+    rclone_listremotes_contents: |
+        {{ [] if not (rclone_listremotes.content | from_json).remotes else (rclone_listremotes.content | from_json).remotes | default([]) }}
 
-# If no existing remotes, API will give `null` response
-- name: Handle null/empty response values
-  ansible.builtin.set_fact:
-    rclone_listremotes_contents: []
-  when: >-
-    rclone_listremotes_contents is undefined
-    or not rclone_listremotes_contents
 
 - name: Create new rclone remotes
   ansible.builtin.include_tasks:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,10 +15,20 @@
   check_mode: false
   changed_when: false
 
-- name: Create rclone gmedia remotes
+- set_fact:
+    rclone_listremotes_contents: "{{ (rclone_listremotes.content | from_json).remotes }}"
+
+# If no existing remotes, API will give `null` response
+- set_fact:
+    rclone_listremotes_contents: []
+  when: >-
+    rclone_listremotes_contents is undefined
+    or not rclone_listremotes_contents
+
+- name: Create new rclone remotes
   ansible.builtin.include_tasks:
     file: rclone-create-remote.yml
-  when: rclone_config.name not in (rclone_listremotes.content | from_json).remotes
+  when: rclone_config.name not in rclone_listremotes_contents
   loop: "{{ rclone_remotes }}"
   loop_control:
     loop_var: rclone_config
@@ -36,7 +46,7 @@
     return_content: true
     headers:
       Accept: application/json
-  loop: "{{ (rclone_listremotes.content | from_json).remotes }}"
+  loop: "{{ rclone_listremotes_contents }}"
   when:
     - remove_undefined_remotes
     - item not in rclone_remotes | map(attribute='name')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,11 +15,13 @@
   check_mode: false
   changed_when: false
 
-- set_fact:
+- name: Parse rc API response
+  set_fact:
     rclone_listremotes_contents: "{{ (rclone_listremotes.content | from_json).remotes }}"
 
 # If no existing remotes, API will give `null` response
-- set_fact:
+- name: Handle null/empty response values
+  set_fact:
     rclone_listremotes_contents: []
   when: >-
     rclone_listremotes_contents is undefined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,12 +16,12 @@
   changed_when: false
 
 - name: Parse rc API response
-  set_fact:
+  ansible.builtin.set_fact:
     rclone_listremotes_contents: "{{ (rclone_listremotes.content | from_json).remotes }}"
 
 # If no existing remotes, API will give `null` response
 - name: Handle null/empty response values
-  set_fact:
+  ansible.builtin.set_fact:
     rclone_listremotes_contents: []
   when: >-
     rclone_listremotes_contents is undefined


### PR DESCRIPTION
In older versions of rclone, they would respond to `listremotes` when no remotes had previously been configured with `[]` in the `content` field.

![image](https://github.com/user-attachments/assets/7ae52178-f526-49bc-8006-e72a2df837b9)

In recent versions (I'm not sure exactly when this behaviour changed), the API will now respond with `null` instead.

![image](https://github.com/user-attachments/assets/e32765d3-d49a-4548-93e5-6ff6256e1dcc)

This caused issues for this role because it would attempt to start a loop over `null`, which would throw an exception in Ansible. This PR first checks the results from the API, and if we were given null or any other falsy value, sets a safe default of `[]`.